### PR TITLE
feat: add /registry/item/<namespace>/<name> recipes to endpoint

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,11 @@ repositories {
             password = project.findProperty("gpr.key") ?: System.getenv("MAVEN_KEY") ?: System.getenv("GITHUB_TOKEN")
         }
     }
+
+    maven {
+		name = "TerraformersMC"
+		url = "https://maven.terraformersmc.com/"
+	}
 }
 
 dependencies {
@@ -152,6 +157,10 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 	
 	testImplementation "junit:junit:4.12"
+
+    compileOnly "dev.emi:emi-neoforge:${emi_version}:api"
+	runtimeOnly "dev.emi:emi-neoforge:${emi_version}:api"
+
 }
 
 subsystems {

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,3 +29,5 @@ neoforge_update_json_url=https://raw.githubusercontent.com/CyclopsMC/Versions/ma
 cyclopscore_version=1.25.1-627
 integrateddynamics_version=1.24.1-1004
 commoncapabilities_version=2.9.3-147
+
+emi_version=1.1.18+1.21.1

--- a/src/main/java/org/cyclops/integratedrest/http/request/handler/RegistryItemRequestHandler.java
+++ b/src/main/java/org/cyclops/integratedrest/http/request/handler/RegistryItemRequestHandler.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import net.minecraft.core.Registry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.world.item.Item;
+import org.cyclops.integratedrest.json.EmiRecipeUtil;
 import org.cyclops.integratedrest.json.JsonUtil;
 
 /**
@@ -19,6 +20,9 @@ public class RegistryItemRequestHandler extends RegistryNamespacedRequestHandler
 
     @Override
     protected void handleElement(Item element, JsonObject jsonObject) {
+
+        EmiRecipeUtil.writeRecipesByOutputItemToNode(element, jsonObject);
+
         JsonUtil.addItemInfo(jsonObject, element);
     }
 

--- a/src/main/java/org/cyclops/integratedrest/json/EmiRecipeUtil.java
+++ b/src/main/java/org/cyclops/integratedrest/json/EmiRecipeUtil.java
@@ -12,20 +12,26 @@ import org.cyclops.integratedrest.IntegratedRest;
 import org.cyclops.integratedrest.http.request.handler.RegistryItemRequestHandler;
 
 public class EmiRecipeUtil {
-    static {
+    private static Class<?> _emiApiClz = null;
+    private static boolean _checkEmi = false;
+
+    private static boolean isEmiLoaded() {
+        if (!_checkEmi) {
+            return _emiApiClz != null;
+        }
+
         try {
-            emiApiClz = RegistryItemRequestHandler.class.getClassLoader().loadClass("dev.emi.emi.api.EmiApi");
+            _emiApiClz = RegistryItemRequestHandler.class.getClassLoader().loadClass("dev.emi.emi.api.EmiApi");
         } catch (ClassNotFoundException e) {
             IntegratedRest.clog(Level.ERROR, e.getMessage());
         }
+        _checkEmi = true;
+        return _emiApiClz != null;
     }
-
-    private static Class<?> emiApiClz = null;
-
 
     public static boolean writeRecipesByOutputItemToNode(Item item, JsonObject rootNode) {
         // skip air
-        if (item.toString().equals("minecraft:air") || emiApiClz == null) {
+        if (item.toString().equals("minecraft:air") || isEmiLoaded()) {
             return false;
         }
 

--- a/src/main/java/org/cyclops/integratedrest/json/EmiRecipeUtil.java
+++ b/src/main/java/org/cyclops/integratedrest/json/EmiRecipeUtil.java
@@ -1,0 +1,81 @@
+package org.cyclops.integratedrest.json;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import dev.emi.emi.api.EmiApi;
+import dev.emi.emi.api.recipe.EmiRecipe;
+import dev.emi.emi.api.stack.EmiStack;
+import dev.emi.emi.api.stack.serializer.EmiIngredientSerializer;
+import net.minecraft.world.item.Item;
+import org.apache.logging.log4j.Level;
+import org.cyclops.integratedrest.IntegratedRest;
+import org.cyclops.integratedrest.http.request.handler.RegistryItemRequestHandler;
+
+public class EmiRecipeUtil {
+    static {
+        try {
+            emiApiClz = RegistryItemRequestHandler.class.getClassLoader().loadClass("dev.emi.emi.api.EmiApi");
+        } catch (ClassNotFoundException e) {
+            IntegratedRest.clog(Level.ERROR, e.getMessage());
+        }
+    }
+
+    private static Class<?> emiApiClz = null;
+
+
+    public static boolean writeRecipesByOutputItemToNode(Item item, JsonObject rootNode) {
+        // skip air
+        if (item.toString().equals("minecraft:air") || emiApiClz == null) {
+            return false;
+        }
+
+        var recipeManager = EmiApi.getRecipeManager();
+        var stack = EmiStack.of(item);
+        var recipesByOutput = recipeManager.getRecipesByOutput(stack);
+
+        var arrNode = new JsonArray();
+        for (EmiRecipe emiRecipe : recipesByOutput) {
+            var categoryId = emiRecipe.getCategory().getId();
+            // skip tag
+            if (categoryId.toString().startsWith("minecraft:tag_recipes")) {
+                continue;
+            }
+
+            var outputs = emiRecipe.getOutputs();
+            boolean flag = false;
+            for (EmiStack output : outputs) {
+                if (output.getId().equals(stack.getId())) flag = true;
+            }
+            if (!flag) {
+                continue;
+            }
+
+            var node = new JsonObject();
+            node.addProperty("id", emiRecipe.getId().toString());
+
+            node.addProperty("category", categoryId.toString());
+
+            var catalystsArrNode = new JsonArray();
+            emiRecipe.getCatalysts().stream().map(x -> {
+                var jsonNode = new JsonObject();
+                var stackArrNode = new JsonArray();
+                x.getEmiStacks().stream().map(EmiIngredientSerializer::getSerialized).forEach(stackArrNode::add);
+                jsonNode.add("inputs", stackArrNode);
+
+                jsonNode.addProperty("amount", x.getAmount());
+                jsonNode.addProperty("chance", x.getChance());
+
+                return jsonNode;
+            }).forEach(catalystsArrNode::add);
+            node.add("catalysts", catalystsArrNode);
+
+            var inputNode = new JsonArray();
+            emiRecipe.getInputs().stream().map(EmiIngredientSerializer::getSerialized).forEach(inputNode::add);
+            node.add("inputs", inputNode);
+
+            arrNode.add(node);
+        }
+        rootNode.add("recipesByOutput", arrNode);
+        return true;
+    }
+}


### PR DESCRIPTION
https://github.com/CyclopsMC/IntegratedREST/issues/26

after(http://[localhost:3000/registry/item/minecraft/oak_planks](http://localhost:3000/registry/item/minecraft/oak_planks)):
```json
{
  "@context": "https://raw.githubusercontent.com/CyclopsMC/IntegratedREST/master-1.21/src/main/resources/context.jsonld",
  "recipesByOutput": [
    {
      "id": "minecraft:oak_planks",
      "category": "minecraft:crafting",
      "catalysts": [
        
      ],
      "inputs": [
        "#item:minecraft:oak_logs"
      ]
    }
  ],
  "@id": "http://localhost:3000/registry/item/minecraft/oak_planks",
  "mod": "http://localhost:3000/registry/mod/minecraft",
  "unlocalizedName": "block.minecraft.oak_planks",
  "resourceLocation": "minecraft:oak_planks",
  "block": "http://localhost:3000/registry/block/minecraft/oak_planks"
}
```
